### PR TITLE
Enable codegen phase and update bootstrap langlib loading logic

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
@@ -1,10 +1,27 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
 package io.ballerina.projects;
 
 import io.ballerina.projects.environment.ModuleLoadRequest;
 import io.ballerina.projects.environment.ModuleLoadResponse;
 import io.ballerina.projects.environment.PackageResolver;
 import org.ballerinalang.model.elements.PackageID;
-import org.wso2.ballerinalang.compiler.Compiler;
 import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.SymbolResolver;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
@@ -12,15 +29,17 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
+import java.util.Collections;
 
 import static org.ballerinalang.model.elements.PackageID.ANNOTATIONS;
-import static org.ballerinalang.model.elements.PackageID.INTERNAL;
 import static org.ballerinalang.model.elements.PackageID.JAVA;
 
+/**
+ * Load lang libs and define their symbols.
+ *
+ * @since 2.0.0
+ */
 class Bootstrap {
 
     private static final Bootstrap instance = new Bootstrap();
@@ -29,26 +48,48 @@ class Bootstrap {
     }
 
     private boolean langLibLoaded = false;
-    private List<PackageID> langLibs = Arrays.asList(
-            ANNOTATIONS,
-            JAVA
-    );
 
-
-    void loadLangLib(CompilerContext compilerContext, PackageResolver packageResolver) {
-        if (!langLibLoaded) {
-            langLibLoaded = true;
-            // we will load any lang.lib found in cache directory
-
-            langLibs.stream().map(packageID -> toModuleRequest(packageID))
-                .forEach(lib -> loadLib(lib, compilerContext, packageResolver));
-            // Update the compiler context
-            loadLangLibFromCache(compilerContext);
+    void loadLangLib(CompilerContext compilerContext, PackageResolver packageResolver, PackageID langLib) {
+        if (langLibLoaded) {
+            return;
         }
+
+        langLibLoaded = true;
+        // we will load any lang.lib found in cache directory
+
+        if (!PackageID.isLangLibPackageID(langLib)) {
+            return;
+        }
+
+        SymbolResolver symResolver = SymbolResolver.getInstance(compilerContext);
+        SymbolTable symbolTable = SymbolTable.getInstance(compilerContext);
+
+        // load annotation
+        ModuleLoadRequest annotation = toModuleRequest(ANNOTATIONS);
+        loadLib(annotation, packageResolver);
+        if (getSymbolFromCache(compilerContext, ANNOTATIONS) != null) {
+            symbolTable.langAnnotationModuleSymbol = getSymbolFromCache(compilerContext, ANNOTATIONS);
+        }
+
+        if (langLib.equals(ANNOTATIONS)) {
+            return;
+        }
+
+        symResolver.reloadErrorAndDependentTypes();
+
+        // load java
+        ModuleLoadRequest java = toModuleRequest(JAVA);
+        loadLib(java, packageResolver);
+
+        if (getSymbolFromCache(compilerContext, JAVA) != null) {
+            symbolTable.langJavaModuleSymbol = getSymbolFromCache(compilerContext, JAVA);
+        }
+
+        // TODO add the rest of the langlibs to load
     }
 
-    private void loadLib(ModuleLoadRequest lib, CompilerContext compilerContext, PackageResolver packageResolver) {
-        Collection<ModuleLoadResponse> modules = packageResolver.loadPackages(Arrays.asList(lib));
+    private void loadLib(ModuleLoadRequest lib, PackageResolver packageResolver) {
+        Collection<ModuleLoadResponse> modules = packageResolver.loadPackages(Collections.singletonList(lib));
         modules.forEach(module -> {
             Package pkg = packageResolver.getPackage(module.packageId());
             PackageCompilation compilation = pkg.getCompilation();
@@ -58,21 +99,11 @@ class Bootstrap {
         });
     }
 
-    ModuleLoadRequest toModuleRequest(PackageID packageID) {
+    private ModuleLoadRequest toModuleRequest(PackageID packageID) {
         PackageName packageName = PackageName.from(packageID.name.getValue());
         ModuleName moduleName = ModuleName.from(packageName);
         SemanticVersion version = SemanticVersion.from(packageID.getPackageVersion().toString());
         return new ModuleLoadRequest(packageID.orgName.getValue(), packageName, moduleName, version);
-    }
-
-
-    private void loadLangLibFromCache(CompilerContext context) {
-        SymbolResolver symResolver = SymbolResolver.getInstance(context);
-        SymbolTable symbolTable = SymbolTable.getInstance(context);
-        if (getSymbolFromCache(context, ANNOTATIONS) != null) {
-            symbolTable.langAnnotationModuleSymbol = getSymbolFromCache(context, ANNOTATIONS);
-            symResolver.reloadErrorAndDependentTypes();
-        }
     }
 
     private BPackageSymbol getSymbolFromCache(CompilerContext context, PackageID packageID) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilation.java
@@ -90,8 +90,6 @@ public class ModuleCompilation {
     }
 
     private void compile() {
-        Bootstrap.getInstance().loadLangLib(compilerContext, packageResolver);
-
         // Compile all the modules
         diagnostics = new ArrayList<>();
         List<ModuleId> sortedModuleIds = dependencyGraph.toTopologicallySortedList();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -61,6 +61,8 @@ class ModuleContext {
     private BLangPackage bLangPackage;
     private List<Diagnostic> diagnostics;
 
+    private PackageResolver packageResolver;
+
     // TODO How about introducing a ModuleState concept. ModuleState.DEPENDENCIES_RESOLVED
     private boolean dependenciesResolved;
 
@@ -77,6 +79,7 @@ class ModuleContext {
         this.testDocContextMap = testDocContextMap;
         this.testSrcDocIds = Collections.unmodifiableCollection(testDocContextMap.keySet());
         this.moduleDependencies = Collections.unmodifiableSet(moduleDependencies);
+        this.packageResolver = project.environmentContext().getService(PackageResolver.class);
     }
 
     private ModuleContext(Project project, ModuleId moduleId, ModuleName moduleName, boolean isDefaultModule,
@@ -183,6 +186,14 @@ class ModuleContext {
 
         PackageID pkgID = new PackageID(new Name(packageDescriptor.org().toString()),
                 new Name(this.moduleName.toString()), new Name(packageDescriptor.version().toString()));
+
+        Bootstrap.getInstance().loadLangLib(compilerContext, packageResolver, pkgID);
+
+        // if this is already loaded from BALO, then skip rest of the compilation
+        if (packageCache.get(pkgID) != null) {
+            return;
+        }
+
         BLangPackage pkgNode = (BLangPackage) TreeBuilder.createPackageNode();
         packageCache.put(pkgID, pkgNode);
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -78,7 +78,6 @@ public class PackageCompilation {
     }
 
     private void compile(CompilerContext compilerContext) {
-        Bootstrap.getInstance().loadLangLib(compilerContext, packageResolver);
         diagnostics = new ArrayList<>();
         // Topologically sort packages in the package dependency graph.
         // Iterate through the sorted package list

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -646,6 +646,8 @@ public class Desugar extends BLangNodeVisitor {
 
         functionSymbol.scope = new Scope(functionSymbol);
         bLangFunction.symbol = functionSymbol;
+
+        env.scope.define(functionSymbol.name, functionSymbol);
     }
 
     /**

--- a/project-api/ballerina-projects/src/main/java/io/ballerina/projects/env/BuildEnvContext.java
+++ b/project-api/ballerina-projects/src/main/java/io/ballerina/projects/env/BuildEnvContext.java
@@ -71,7 +71,7 @@ public class BuildEnvContext extends EnvironmentContext {
         compilerContext = new CompilerContext();
         CompilerOptions options = CompilerOptions.getInstance(compilerContext);
         options.put(PROJECT_DIR, "../../langlib/lang.annotations/src/main/ballerina");
-        options.put(COMPILER_PHASE, CompilerPhase.BIR_GEN.toString());
+        options.put(COMPILER_PHASE, CompilerPhase.CODE_GEN.toString());
 
         // TODO This is a temporary property to compile lang lib modules from source
         System.setProperty("BALLERINA_DEV_COMPILE_BALLERINA_ORG", "true");


### PR DESCRIPTION
## Purpose
Updating so that the expected ordering of symbol resolving is kept intact starting from annotation and the rest.

Also added logic to skip compiling langlibs which are already loaded/compiled by Bootstrap

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
